### PR TITLE
Added new filter on qwc_front

### DIFF
--- a/qwc-front.php
+++ b/qwc-front.php
@@ -33,6 +33,7 @@ function qwc_add_filters_front() {
 
 		/* two-argument filters */
 		'woocommerce_attribute_label' => 20,
+		'woocommerce_get_product_attributes' => 1,
 		'woocommerce_cart_shipping_method_full_label' => 20,
 		'woocommerce_cart_tax_totals' => 20,
 		'woocommerce_email_footer_text' => 20,


### PR DESCRIPTION
Added a new filter on the qwc_front.
I had the issue that the variations that were made with attributes such as [:en]Black Color[:].... were not being shown on the front end in the dropdown element. 

By using this filter, they are shown with no issues.
