### PR TITLE
Don't cache product _stock and _stock_status

### DIFF
--- a/qwc-front.php
+++ b/qwc-front.php
@@ -99,6 +99,8 @@ function qwc_filter_postmeta($original_value, $object_id, $meta_key = '', $singl
 	//qtranxf_dbg_log_if($object_id==58,'qwc_filter_postmeta: $object_id='.$object_id.' $meta_key:',$meta_key);
 	switch($meta_key){
 		case '_product_attributes':
+		case '_stock':
+		case '_stock_status':
 			return $original_value;
 		default: return qtranxf_filter_postmeta($original_value, $object_id, $meta_key, $single);
 	}


### PR DESCRIPTION
This fixes the invalid stock reduction when orders are placed (WC3+). 

E.g. when an order was placed while only 1 product was left in stock the notification would become 'stock reduced from 2 to 1', but in fact it was reduced from 1 to 0. Also out-of-stock status would not be set.